### PR TITLE
Full commit info when <cr> on a blame line

### DIFF
--- a/lua/blame/git.lua
+++ b/lua/blame/git.lua
@@ -1,0 +1,33 @@
+local M = {}
+
+---Execute git blame line porcelain command
+---@param filename string
+---@param cwd any cwd where to execute the command
+---@param on_exit any callback on exiting the command
+---@param on_stdout any
+M.blame = function(filename, cwd, on_exit, on_stdout)
+	local blame_command = "git --no-pager blame --line-porcelain " .. filename
+	vim.fn.jobstart(blame_command, {
+		cwd = cwd,
+		on_exit = on_exit,
+		on_stdout = on_stdout,
+		stdout_buffered = true,
+	})
+end
+
+---Execute git show command
+---@param hash string git object hash to get git show for
+---@param cwd any cwd where to execute the command
+---@param on_exit any callback on exiting the command
+---@param on_stdout any
+M.show = function(hash, cwd, on_exit, on_stdout)
+	local blame_command = "git show " .. hash
+	vim.fn.jobstart(blame_command, {
+		cwd = cwd,
+		on_exit = on_exit,
+		on_stdout = on_stdout,
+		stdout_buffered = true,
+	})
+end
+
+return M

--- a/lua/blame/window_blame.lua
+++ b/lua/blame/window_blame.lua
@@ -1,10 +1,38 @@
 local util = require("blame.util")
 local highlights = require("blame.highlights")
+local git = require("blame.git")
 
 local M = {}
 M.blame_window = nil
 M.blame_buffer = nil
 M.original_window = nil
+M.gshow_output = nil
+
+---Sets the autocommands for the blame buffer
+local function setup_autocmd(blame_buff)
+	vim.api.nvim_create_autocmd({ "BufHidden", "BufUnload" }, {
+		callback = function()
+			if M.blame_buffer ~= nil then
+				M.reset_to_closed_state()
+			end
+		end,
+		buffer = blame_buff,
+		group = "BlameNvim",
+		desc = "Reset state to closed when the buffer is exited.",
+	})
+end
+
+---Sets the keybinds for the blame buffer
+local function setup_keybinds(buff)
+	vim.keymap.set("n", "q", ":q<cr>", { buffer = buff, nowait = true, silent = true, noremap = true })
+	vim.keymap.set("n", "<esc>", ":q<cr>", { buffer = buff, nowait = true, silent = true, noremap = true })
+	vim.keymap.set(
+		"n",
+		"<cr>",
+		[[:lua require("blame.window_blame").show_full_commit()<cr>]],
+		{ buffer = buff, nowait = true, silent = true, noremap = true }
+	)
+end
 
 M.window_blame = function(blame_lines, config)
 	local width = config["width"] or (util.longest_string_in_array(blame_lines) + 8)
@@ -22,6 +50,9 @@ M.window_blame = function(blame_lines, config)
 
 	util.scroll_to_same_position(M.original_window, M.blame_window)
 
+	setup_keybinds(M.blame_buffer)
+	setup_autocmd(M.blame_buffer)
+
 	vim.api.nvim_win_set_cursor(M.blame_window, cursor_pos)
 
 	vim.api.nvim_set_option_value("cursorbind", true, { win = M.original_window })
@@ -37,9 +68,51 @@ M.window_blame = function(blame_lines, config)
 	vim.api.nvim_buf_set_option(M.blame_buffer, "modifiable", false)
 end
 
+---Git show command done callback
+---@param _ any
+---@param status any exit status of command
+local function show_done(_, status)
+	if status == 0 and M.gshow_output ~= nil then
+		local hash = M.gshow_output[1]:match("commit (%S+)")
+		local gshow_buff = vim.api.nvim_create_buf(true, true)
+		vim.api.nvim_set_current_win(M.original_window)
+
+		vim.api.nvim_buf_set_lines(gshow_buff, 0, -1, false, M.gshow_output)
+		vim.api.nvim_buf_set_option(gshow_buff, "filetype", "git")
+		vim.api.nvim_buf_set_name(gshow_buff, hash)
+		vim.api.nvim_buf_set_option(gshow_buff, "readonly", true)
+		vim.api.nvim_set_current_buf(gshow_buff)
+		vim.api.nvim_win_set_buf(M.original_window, gshow_buff)
+		M.close_window()
+	else
+		vim.notify("Could not open full commit info", vim.log.levels.INFO)
+	end
+end
+
+---Output of git show
+---@param _ any
+---@param gshow_output any stdout output of git show
+local function show_output(_, gshow_output)
+	M.gshow_output = gshow_output
+end
+
+---Get git show output for hash under cursor
+M.show_full_commit = function()
+	local row, _ = unpack(vim.api.nvim_win_get_cursor(M.blame_window))
+	local blame_line = vim.api.nvim_buf_get_lines(M.blame_buffer, row - 1, row, false)[1]
+	local hash = blame_line:match("^%S+")
+	git.show(hash, vim.fn.getcwd(), show_done, show_output)
+end
+
+---Close the blame window
 M.close_window = function()
+	local buff = M.blame_buffer
 	vim.api.nvim_win_close(M.blame_window, true)
-	vim.api.nvim_buf_delete(M.blame_buffer, { force = true })
+	vim.api.nvim_buf_delete(buff, { force = true })
+end
+
+---Reset the state to initial/closed state
+M.reset_to_closed_state = function()
 	vim.api.nvim_set_option_value("cursorbind", false, { win = M.original_window })
 	vim.api.nvim_set_option_value("scrollbind", false, { win = M.original_window })
 	M.original_window = nil

--- a/lua/blame/window_blame.lua
+++ b/lua/blame/window_blame.lua
@@ -66,6 +66,7 @@ M.window_blame = function(blame_lines, config)
 	vim.api.nvim_set_current_win(M.original_window)
 	highlights.highlight_same_hash(M.blame_buffer)
 	vim.api.nvim_buf_set_option(M.blame_buffer, "modifiable", false)
+	vim.api.nvim_buf_set_option(M.blame_buffer, "spell", false)
 end
 
 ---Git show command done callback

--- a/lua/blame/window_blame.lua
+++ b/lua/blame/window_blame.lua
@@ -66,7 +66,7 @@ M.window_blame = function(blame_lines, config)
 	vim.api.nvim_set_current_win(M.original_window)
 	highlights.highlight_same_hash(M.blame_buffer)
 	vim.api.nvim_buf_set_option(M.blame_buffer, "modifiable", false)
-	vim.api.nvim_buf_set_option(M.blame_buffer, "spell", false)
+	vim.api.nvim_win_set_option(M.blame_window, "spell", false)
 end
 
 ---Git show command done callback

--- a/plugin/blame_nvim.lua
+++ b/plugin/blame_nvim.lua
@@ -1,1 +1,11 @@
-vim.api.nvim_create_user_command("ToggleBlame", require("blame").toggle, { nargs = "*" })
+vim.api.nvim_create_user_command("ToggleBlame", function(args)
+	require("blame").toggle(args)
+end, { nargs = "*" })
+
+vim.api.nvim_create_user_command("EnableBlame", function(args)
+	require("blame").enable(args)
+end, { nargs = "*" })
+
+vim.api.nvim_create_user_command("DisableBlame", function()
+	require("blame").disable()
+end, {})


### PR DESCRIPTION
Opens 'git show' when CR on a blame line in a new window.
Adds 'q' and 'esc' exit binds to the blame window.

Adds #1 

Adds first and second point from #2 

Adds #4 

