### PR TITLE
Fix bug when opening files with spaces in their paths

### DIFF
--- a/lua/blame/git.lua
+++ b/lua/blame/git.lua
@@ -6,7 +6,7 @@ local M = {}
 ---@param on_exit any callback on exiting the command
 ---@param on_stdout any
 M.blame = function(filename, cwd, on_exit, on_stdout)
-	local blame_command = "git --no-pager blame --line-porcelain " .. filename
+	local blame_command = "git --no-pager blame --line-porcelain \"" .. filename .. "\""
 	vim.fn.jobstart(blame_command, {
 		cwd = cwd,
 		on_exit = on_exit,


### PR DESCRIPTION
This commit simply wraps the path provided to git with quotes to ensure that git does not get confused.