### PR TITLE
Enhancements to Commit Detail Display and Buffer Setup Refactoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,4 +37,5 @@ These are the fields you can configure by passing them to the `require('blame').
 - `date_format` - string - Pattern for the date (default: "%Y/%m/%d %H:%M")
 - `virtual_style` - "right_align" or "float" - Float moves the virtual text close to the content of the file. (default : "right_align")
 - `merge_consecutive` - boolean - Merge consecutive blames that are from the same commit
+- `commit_detail_view` - string - "tab"|"split"|"vsplit"|"current" - Open commit details in a new tab, split, vsplit or current buffer
 

--- a/lua/blame.lua
+++ b/lua/blame.lua
@@ -9,11 +9,13 @@ local git = require("blame.git")
 ---@field width number|nil Manual setup of window width
 ---@field virtual_style "float"|"right_align"
 ---@field merge_consecutive boolean Should same commits be ignored after first line
+---@field commit_detail_view string "tab"|"split"|"vsplit"|"current" How to open commit details
 local config = {
 	date_format = "%Y/%m/%d %H:%M",
 	width = nil,
 	virtual_style = "right_align",
 	merge_consecutive = false,
+    commit_detail_view = "tab",
 }
 
 ---@class Blame


### PR DESCRIPTION
This pull request introduces enhancements to the commit detail display functionality within the plugin, allowing users more flexibility in how commit details are shown (e.g., in a new tab, vertical split, horizontal split, or directly in the current buffer). It also includes a significant refactor of the buffer setup process to streamline the code and improve maintainability.

1. Expanded Display Options: Introduced new configuration options for displaying commit details: "tab", "split", "vsplit", and "current". This enhancement allows users to select their preferred display method via the plugin's setup configuration, with "tab" being the default option. Users can update their preference as follows:
```lua
require("blame").setup({
    commit_detail_view = "tab",
})
```
2. Code Refactoring and Error Handling: The show_done function has been refactored to incorporate error handling for enhanced robustness, as well as to support the new configuration options. Additionally, part of the buffer setup logic has been abstracted into a new function, setup_commit_buffer, to centralize and simplify buffer preparation tasks.