### PR TITLE
Implement config option for custom hash colors

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ These are the fields you can configure by passing them to the `require('blame').
 - `virtual_style` - "right_align" or "float" - Float moves the virtual text close to the content of the file. (default : "right_align")
 - `merge_consecutive` - boolean - Merge consecutive blames that are from the same commit
 - `commit_detail_view` - string - "tab"|"split"|"vsplit"|"current" - Open commit details in a new tab, split, vsplit or current buffer
+- `colors` - string[] - List of hex colors, defaults to nil which will use a random color for each commit hash
 
 ### Custom format example.
 

--- a/lua/blame.lua
+++ b/lua/blame.lua
@@ -11,6 +11,7 @@ local git = require("blame.git")
 ---@field virtual_style "float"|"right_align"
 ---@field merge_consecutive boolean Should same commits be ignored after first line
 ---@field commit_detail_view string "tab"|"split"|"vsplit"|"current" How to open commit details
+---@field colors string[]|nil Custom colors for the highlights
 local config = {
 	date_format = "%Y/%m/%d %H:%M",
 	format = nil,
@@ -18,6 +19,7 @@ local config = {
 	virtual_style = "right_align",
 	merge_consecutive = false,
 	commit_detail_view = "tab",
+    colors = nil,
 }
 
 ---@class Blame
@@ -51,7 +53,7 @@ local function done(blame_type)
 			return
 		end
 		local parsed_blames = blame_parser.parse_porcelain(M.blame_lines)
-		highlights.map_highlights_per_hash(parsed_blames)
+		highlights.map_highlights_per_hash(parsed_blames, M.config)
 
 		if blame_type == "window" or blame_type == "" then
 			window_blame.window_blame(parsed_blames, M.config)

--- a/lua/blame/highlights.lua
+++ b/lua/blame/highlights.lua
@@ -2,11 +2,16 @@ local M = {}
 M.nsId = nil
 
 ---@return string
-local function random_rgb()
-	local r = math.random(100, 255)
-	local g = math.random(100, 255)
-	local b = math.random(100, 255)
-	return string.format("#%02X%02X%02X", r, g, b)
+local function random_rgb(custom_colors)
+    if custom_colors and #custom_colors > 0 then
+        local index = math.random(1, #custom_colors)
+        return custom_colors[index]
+    else
+        local r = math.random(100, 255)
+        local g = math.random(100, 255)
+        local b = math.random(100, 255)
+        return string.format("#%02X%02X%02X", r, g, b)
+    end
 end
 
 M.setup_highlights = function()
@@ -17,13 +22,14 @@ end
 
 ---Creates the highlights for Hash, NotCommited and random color per one hash
 ---@param parsed_lines any
-M.map_highlights_per_hash = function(parsed_lines)
+---@param config Config
+M.map_highlights_per_hash = function(parsed_lines, config)
 	M.nsId = vim.api.nvim_create_namespace("blame_ns")
 	for _, value in ipairs(parsed_lines) do
 		local full_hash = value["hash"]
 		local hash = string.sub(full_hash, 0, 8)
 		if next(vim.api.nvim_get_hl(M.nsId, { name = hash })) == nil then
-			vim.api.nvim_set_hl(M.nsId, hash, { fg = random_rgb(), })
+			vim.api.nvim_set_hl(M.nsId, hash, { fg = random_rgb(config.colors), })
 		end
 	end
 end

--- a/lua/blame/highlights.lua
+++ b/lua/blame/highlights.lua
@@ -1,6 +1,7 @@
 local M = {}
 M.nsId = nil
 
+---@param custom_colors string[]
 ---@return string
 local function random_rgb(custom_colors)
     if custom_colors and #custom_colors > 0 then


### PR DESCRIPTION
This feature will allow users to add a list of hex colors to their config to enhance the blame pane to match their theme. This is a simple approach, we could potentially extend this to include theme colors via the API, but this should cover most scenarios and give more control over the specific colors to use.

Features
- Adds config option for adding a hex list of colors
- defaults to nil which will fallback to the random color picker that is currently in use