### PR TITLE
fix: handle previous blame with space in file name

### DIFF
--- a/lua/blame/porcelain_parser.lua
+++ b/lua/blame/porcelain_parser.lua
@@ -11,7 +11,7 @@ local M = {}
 ---@field committer_tz string
 ---@field filename string
 ---@field hash string
----@field previous string
+---@field previous string|nil
 ---@field summary string
 ---@field content string
 


### PR DESCRIPTION
Use `match("(.-) (.+)")` instead of `split`, and also some refactoring.