### PR TITLE
fix: cwd for show_full_commit

### DIFF
--- a/lua/blame/views/window_view.lua
+++ b/lua/blame/views/window_view.lua
@@ -168,6 +168,7 @@ function WindowView:open(lines)
         vim.api.nvim_win_get_buf(self.original_window)
     )
     local cwd = vim.fn.expand("%:p:h")
+    self.cwd = cwd
     self.blame_stack_client =
         BlameStack:new(self.config, self, self.original_window, file_path, cwd)
 end
@@ -343,7 +344,7 @@ function WindowView:show_full_commit()
     local view = self.config.commit_detail_view or "tab"
     self.git_client:show(
         nil,
-        vim.fn.getcwd(),
+        self.cwd,
         commit.hash,
         function(show_output)
             vim.schedule(function()


### PR DESCRIPTION
Fix a bug : 
- Open a file
- Cwd of vim must be different than the git root of the file
- Open git blame window
- Press enter on a commit

=> Error "fatal: not a git repository (or any of the parent directories): .git"