### PR TITLE
Fix scroll sync issues with `scrolloff=999`

### DIFF
--- a/lua/blame/views/window_view.lua
+++ b/lua/blame/views/window_view.lua
@@ -200,37 +200,7 @@ function WindowView:update_opened_blame_view(blame_lines, lines_with_hl)
 
     vim.bo[vim.api.nvim_win_get_buf(self.blame_window)].modifiable = false
 
-    -- Have to disable all options while syncing scroll on update
-    for option, value in pairs(blame_enabled_options) do
-        vim.api.nvim_set_option_value(
-            option,
-            not value,
-            { win = self.blame_window }
-        )
-
-        vim.api.nvim_set_option_value(
-            option,
-            not value,
-            { win = self.original_window }
-        )
-    end
-
     scroll_to_same_position(self.original_window, self.blame_window)
-
-    -- and re-enable them here
-    for option, value in pairs(blame_enabled_options) do
-        vim.api.nvim_set_option_value(
-            option,
-            value,
-            { win = self.blame_window }
-        )
-
-        vim.api.nvim_set_option_value(
-            option,
-            value,
-            { win = self.original_window }
-        )
-    end
 end
 
 function WindowView:close(cleanup)


### PR DESCRIPTION
I use `scrolloff=999` to keep the cursor always centered. When trying this plugin, I immediately noticed sync issues when going more than one commit deep into a blame stack.

For a reproduction, try the following:

1. Checkout the `Homebrew/brew` repo at revision 3b40ab6680e
2. Open `Library/Homebrew/cmd/outdated.rb`
3. `:set scrolloff=999`
4. `:BlameToggle`
5. At line 1, push onto the blame stack with `<TAB>`
6. At line 57, push onto the blame stack with `<TAB>`
7. Notice the sync issues. (e.g. scroll to the bottom with `G`)

With this PR, I do not notice any sync issues using `scrolloff=999`. Additionally, I tested this with `scrolloff=0`, and the existing behavior seems to be intact.

I am not sure why this code is in place, but presumably there is a reason. That means there may be a better solution to this issue, but in the meantime I have not noticed any negative effects while using this PR.