### PR TITLE
Fix spelling

### DIFF
--- a/lua/blame/formats/default_formats.lua
+++ b/lua/blame/formats/default_formats.lua
@@ -32,7 +32,7 @@ M.commit_date_author_fn = function(line_porcelain, config, idx)
             idx = idx,
             values = {
                 {
-                    textValue = "Not commited",
+                    textValue = "Not committed",
                     hl = "Comment",
                 },
             },


### PR DESCRIPTION
Change spelling of the word `committed`.