### PR TITLE
Add config for relative date if the changes is last month

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Default config:
 {
     date_format = "%d.%m.%Y",
     virtual_style = "right_align",
+    relative_date_if_recent = true -- this is relative only for the latest month
     views = {
         window = window_view,
         virtual = virtual_view,

--- a/lua/blame.lua
+++ b/lua/blame.lua
@@ -33,6 +33,7 @@ local formats = require("blame.formats.default_formats")
 ---@field mappings Mappings
 local config = {
     date_format = "%d.%m.%Y",
+    relative_date_if_recent = true, -- Show relative date if commit is < 1 month
     virtual_style = "right_align",
     views = {
         window = window_view,

--- a/lua/blame/formats/default_formats.lua
+++ b/lua/blame/formats/default_formats.lua
@@ -6,7 +6,13 @@ M.commit_date_author_fn = function(line_porcelain, config, idx)
     local hash = string.sub(line_porcelain.hash, 0, 7)
     local line_with_hl = {}
     local is_commited = hash ~= "0000000"
+    local date_text
     if is_commited then
+        if config.relative_date_if_recent then
+            date_text = utils.format_recent_date(config.date_format, line_porcelain.committer_time)
+        else
+            date_text = utils.format_time(config.date_format, line_porcelain.committer_time)
+        end
         line_with_hl = {
             idx = idx,
             values = {
@@ -15,10 +21,7 @@ M.commit_date_author_fn = function(line_porcelain, config, idx)
                     hl = "Comment",
                 },
                 {
-                    textValue = utils.format_time(
-                        config.date_format,
-                        line_porcelain.committer_time
-                    ),
+                    textValue = date_text,
                     hl = hash,
                 },
                 {

--- a/lua/blame/utils.lua
+++ b/lua/blame/utils.lua
@@ -51,4 +51,17 @@ M.format_time = function(format, timestamp)
     end
 end
 
+--- Formats a timestamp as relative if < 1 month, else absolute
+--- @param format string: Format string for absolute date
+--- @param timestamp number: UNIX timestamp
+--- @return string
+M.format_recent_date = function(format, timestamp)
+    local diff = os.time() - timestamp
+    if diff < 2592000 then -- < 30 days
+        return relative_time(timestamp)
+    else
+        return tostring(os.date(format, timestamp))
+    end
+end
+
 return M


### PR DESCRIPTION
This changes adds a simple feature, make the date relative if the date is less then a month


If you prefer I keep it `false` by default

<img width="580" height="218" alt="Screenshot 2025-09-08 at 16 04 51" src="https://github.com/user-attachments/assets/dc8fbaac-2c9a-4e06-8cac-a9bf784b2589" />

