### PR TITLE
Replace nvim_buf_add_highlight with nvim_buf_set_extmark

### DIFF
--- a/lua/blame/blame_stack.lua
+++ b/lua/blame/blame_stack.lua
@@ -195,14 +195,10 @@ function BlameStack:open_stack_info_float()
 
         local lns = vim.api.nvim_buf_get_lines(info_buf, 0, -1, false)
         for idx, v in ipairs(lns) do
-            vim.api.nvim_buf_add_highlight(
-                info_buf,
-                -1,
-                idx == #lns and string.sub(v, 0, 7) or "Comment",
-                idx - 1,
-                0,
-                -1
-            )
+            vim.api.nvim_buf_set_extmark(info_buf, -1, idx - 1, 0, {
+                end_col = -1,
+                hl_group = idx == #lns and string.sub(v, 0, 7) or "Comment",
+            })
         end
 
         local width = utils.longest_string_in_array(lines_text) + 5
@@ -227,14 +223,10 @@ function BlameStack:open_stack_info_float()
     end
     vim.api.nvim_buf_set_lines(info_buf, 0, -1, false, lines_text)
 
-    vim.api.nvim_buf_add_highlight(
-        info_buf,
-        -1,
-        string.sub(lines_text[1], 0, 7),
-        0,
-        0,
-        -1
-    )
+    vim.api.nvim_buf_set_extmark(info_buf, -1, 0, 0, {
+        end_col = -1,
+        hl_group = string.sub(lines_text[1], 0, 7),
+    })
 
     local width = utils.longest_string_in_array(lines_text) + 5
     local height = #self.commit_stack

--- a/lua/blame/commit_info.lua
+++ b/lua/blame/commit_info.lua
@@ -57,14 +57,10 @@ function CommitInfo:open(commit)
 
     for idx, line in ipairs(formatted_commit) do
         local key_end = string.find(line, ":") - 1
-        vim.api.nvim_buf_add_highlight(
-            info_buf,
-            self.config.ns_id,
-            "Comment",
-            idx - 1,
-            0,
-            key_end
-        )
+        vim.api.nvim_buf_set_extmark(info_buf, self.config.ns_id, idx - 1, 0, {
+            end_col = key_end,
+            hl_group = "Comment",
+        })
     end
 
     mappings.set_keymap(

--- a/lua/blame/views/window_view.lua
+++ b/lua/blame/views/window_view.lua
@@ -81,13 +81,15 @@ function WindowView:add_highlights(lines_with_hl)
                 local startindex, endindex =
                     string.find(text_line, value.textValue, nil, true)
                 if startindex ~= nil and endindex ~= nil then
-                    vim.api.nvim_buf_add_highlight(
+                    vim.api.nvim_buf_set_extmark(
                         vim.api.nvim_win_get_buf(self.blame_window),
                         self.config.ns_id,
-                        value.hl,
                         line.idx - 1,
                         startindex - 1,
-                        endindex
+                        {
+                            end_col = endindex,
+                            hl_group = value.hl,
+                        }
                     )
                 end
             end


### PR DESCRIPTION
Replaces usage of the deprecated `nvim_buf_add_highlight` across `blame_stack.lua`, `commit_info.lua`, and `window_view.lua` with the modern Extmark API function `nvim_buf_set_extmark`.

This transition ensures compatibility and future-proofs the codebase, as the highlighting feature is now handled through Extmarks using the `hl_group` option.

