### PR TITLE
fix: allow using %r with relative_date_if_recent

### DIFF
--- a/lua/blame/utils.lua
+++ b/lua/blame/utils.lua
@@ -60,7 +60,7 @@ M.format_recent_date = function(format, timestamp)
     if diff < 2592000 then -- < 30 days
         return relative_time(timestamp)
     else
-        return tostring(os.date(format, timestamp))
+        return M.format_time(format, timestamp)
     end
 end
 


### PR DESCRIPTION
With the following config:

``` lua
local blame = require("blame")
blame.setup({ date_format = "%r" })
```

The date formatting looks like this:

<img width="1064" height="520" alt="image" src="https://github.com/user-attachments/assets/decaa4ac-62f0-476c-af35-5238da2c0758" />

I worked around this by disabling `relative_date_if_recent`:

``` lua
local blame = require("blame")
blame.setup({ 
	date_format = "%r",
	relative_date_if_recent = false
})
```
