### PR TITLE
fix: resolve cwd from file path for nested git repos

### DIFF
--- a/lua/blame/views/window_view.lua
+++ b/lua/blame/views/window_view.lua
@@ -178,7 +178,7 @@ function WindowView:open(lines)
     local file_path = vim.api.nvim_buf_get_name(
         vim.api.nvim_win_get_buf(self.original_window)
     )
-    local cwd = vim.fn.expand("%:p:h")
+    local cwd = vim.fn.fnamemodify(file_path, ":h")
     self.cwd = cwd
     self.blame_stack_client =
         BlameStack:new(self.config, self, file_path, cwd)


### PR DESCRIPTION
Hey there and thanks for this great project! I've been using it pretty much daily in my workflow.

Recently there was a change in our project setup, which lead to it breaking for me:
When a file lives in a nested git repo (child B inside a subfolder of parent A), blame works correctly but commit operations (Enter to show commit, `o` to open in browser, Tab for blame stack) fail because the commit hash can't be found in the parent repo.

**Root cause:** `vim.fn.expand("%:p:h")` is evaluated after focus moves to the blame scratch buffer, which has no file name — so it falls back to neovim's cwd (the parent repo) instead of the file's actual repo.

**Fix:** Derive `cwd` from the already-resolved `file_path` (which is correctly read from the original window's buffer) using `vim.fn.fnamemodify(file_path, ":h")`.