### PR TITLE
fix: use the author time instead of the committer time

### DIFF
--- a/lua/blame/blame_stack.lua
+++ b/lua/blame/blame_stack.lua
@@ -203,7 +203,7 @@ function BlameStack:open_stack_info_float()
                     .. " "
                     .. v.author
                     .. " "
-                    .. utils.format_time(self.config.date_format, v.committer_time)
+                    .. utils.format_time(self.config.date_format, v.author_time)
             )
         end
         vim.api.nvim_buf_set_lines(info_buf, 0, -1, false, lines_text)
@@ -237,7 +237,7 @@ function BlameStack:open_stack_info_float()
                 .. " "
                 .. v.author
                 .. " "
-                .. utils.format_time(self.config.date_format, v.committer_time)
+                .. utils.format_time(self.config.date_format, v.author_time)
         )
     end
     vim.api.nvim_buf_set_lines(info_buf, 0, -1, false, lines_text)

--- a/lua/blame/formats/default_formats.lua
+++ b/lua/blame/formats/default_formats.lua
@@ -9,9 +9,9 @@ M.commit_date_author_fn = function(line_porcelain, config, idx)
     local date_text
     if is_commited then
         if config.relative_date_if_recent then
-            date_text = utils.format_recent_date(config.date_format, line_porcelain.committer_time)
+            date_text = utils.format_recent_date(config.date_format, line_porcelain.author_time)
         else
-            date_text = utils.format_time(config.date_format, line_porcelain.committer_time)
+            date_text = utils.format_time(config.date_format, line_porcelain.author_time)
         end
         line_with_hl = {
             idx = idx,
@@ -68,7 +68,7 @@ M.date_message = function(line_porcelain, config, idx)
                 {
                     textValue = utils.format_time(
                         config.date_format,
-                        line_porcelain.committer_time
+                        line_porcelain.author_time
                     ),
                     hl = "Comment",
                 },


### PR DESCRIPTION
When you run `git blame` it shows the author time, not the committer time to prevent rebases from affecting the blame info. This PR changes the plugin to have the same behaviour as `git blame`