### PR TITLE
Fixes commit opening from blame stack history.

### DIFF
--- a/lua/blame/blame_stack.lua
+++ b/lua/blame/blame_stack.lua
@@ -18,6 +18,7 @@ local mappings = require("blame.mappings")
 ---@field commit_stack Porcelain[]
 ---@field cursor_stack unknown[]
 ---@field original_cursor unknown
+---@field suppress_stack_autocmd boolean
 local BlameStack = {}
 
 ---@return BlameStack
@@ -46,6 +47,7 @@ function BlameStack:new(config, blame_view, file_path, cwd)
 
     o.commit_stack = {}
     o.cursor_stack = {}
+    o.suppress_stack_autocmd = false
 
     return o
 end
@@ -157,7 +159,13 @@ function BlameStack:create_blame_buf()
 
     vim.api.nvim_create_autocmd({ "BufHidden", "BufUnload" }, {
         callback = function()
+            if self.suppress_stack_autocmd then
+                return
+            end
             vim.schedule(function()
+                if self.suppress_stack_autocmd then
+                    return
+                end
                 self:reset_to_original_buf()
                 self:close()
                 if self.config.focus_blame then
@@ -174,11 +182,13 @@ end
 function BlameStack:reset_to_original_buf()
     self.commit_stack = {}
     self.cursor_stack = {}
+    self.suppress_stack_autocmd = true
     vim.api.nvim_set_current_win(self.original_window)
     vim.api.nvim_set_current_buf(self.original_buffer)
     if self.stack_buffer and vim.api.nvim_buf_is_valid(self.stack_buffer) then
         vim.api.nvim_buf_delete(self.stack_buffer, { force = true })
     end
+    self.suppress_stack_autocmd = false
     ---@diagnostic disable-next-line: missing-fields
     self:get_blame_for_commit({}, false, function(blame_lines)
         vim.schedule(function()
@@ -285,6 +295,7 @@ end
 
 function BlameStack:close()
     self:close_stack_info_float()
+    self.suppress_stack_autocmd = true
     if vim.api.nvim_win_is_valid(self.original_window) then
         vim.api.nvim_win_set_buf(self.original_window, self.original_buffer)
     end
@@ -294,6 +305,7 @@ function BlameStack:close()
     then
         vim.api.nvim_buf_delete(self.stack_buffer, { force = true })
     end
+    self.suppress_stack_autocmd = false
     self.stack_buffer = nil
     self.commit_stack = {}
 end

--- a/lua/blame/views/window_view.lua
+++ b/lua/blame/views/window_view.lua
@@ -403,18 +403,11 @@ function WindowView:show_full_commit()
                     self.original_window
                 )
 
-                if view == "tab" then
-                    vim.cmd("tabnew")
-                elseif view == "vsplit" then
-                    vim.cmd("vsplit")
-                elseif view == "split" then
-                    vim.cmd("split")
-                end
-
                 if view == "current" then
                     vim.api.nvim_win_set_buf(self.original_window, gshow_buff)
                     self:close()
                 else
+                    local original_window = self.original_window
                     mappings.set_keymap("n", "close", ":q<CR>", {
                         buffer = gshow_buff,
                         nowait = true,
@@ -422,6 +415,19 @@ function WindowView:show_full_commit()
                         noremap = true,
                     }, self.config)
                     self:close()
+                    if
+                        original_window
+                        and vim.api.nvim_win_is_valid(original_window)
+                    then
+                        vim.api.nvim_set_current_win(original_window)
+                    end
+                    if view == "tab" then
+                        vim.cmd("tabnew")
+                    elseif view == "vsplit" then
+                        vim.cmd("vsplit")
+                    elseif view == "split" then
+                        vim.cmd("split")
+                    end
                     vim.api.nvim_win_set_buf(
                         vim.api.nvim_get_current_win(),
                         gshow_buff


### PR DESCRIPTION
When pressing `<Tab>` in the blame buffer to inspect previous file states, then pressing `<CR>` on a commit, the plugin did not behave like the normal latest-blame state. The blame stack buffer could trigger its cleanup autocmd  while the commit view was opening, causing the blame buffer to reset to the latest state or stealing focus from the commit buffer.

This PR suppresses the stack-buffer cleanup autocmd during internal stack restoration/closure, and restores the  original file window before applying the configured commit_detail_view such as vsplit. As a result, opening a  commit from a historical blame state now closes the blame UI and focuses the commit buffer consistently with  opening a commit from the latest blame state.

I vibed this PullRequets, but it does fix this bug, If you have a better solution, feel free to close it and fix it by yourself.